### PR TITLE
refactor: Replace cidr-utils with cidr crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ graphql = ["async-graphql"]
 
 [dependencies]
 async-graphql = { version = "^7.0", default-features = false, optional = true }
-cidr-utils = "^0.6"
+cidr = "^0.3"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value
 #[cfg(feature = "serialize")]
 mod serialize;
 
-use cidr_utils::cidr::IpCidr;
+use cidr::IpCidr;
 use std::collections::{hash_set::IntoIter, HashSet};
 use std::net::IpAddr;
 use std::str::FromStr;


### PR DESCRIPTION
It is not necessary to include `cidr-utils` crate that adds another two dependency as it is necessary just to include `cidr` crate directly.